### PR TITLE
fix: mark some assets as not mounted by default

### DIFF
--- a/legacy_schrodinger/addon.kv3
+++ b/legacy_schrodinger/addon.kv3
@@ -22,4 +22,5 @@
 	assets = 
 	{
 	}
+	mounted_by_default = false
 }

--- a/p1_pgun/addon.kv3
+++ b/p1_pgun/addon.kv3
@@ -24,4 +24,5 @@
 	assets = 
 	{
 	}
+	mounted_by_default = false
 }

--- a/player_blood/addon.kv3
+++ b/player_blood/addon.kv3
@@ -18,4 +18,5 @@
 	assets = 
 	{
 	}
+	mounted_by_default = false
 }

--- a/unused_turret_vo/addon.kv3
+++ b/unused_turret_vo/addon.kv3
@@ -21,4 +21,5 @@
 	assets = 
 	{
 	}
+	mounted_by_default = false
 }


### PR DESCRIPTION
This will not do anything yet, as it is dependent on an internal PR, however it can be merged without issue and the functionality will start working later. Let me know if you disagree with what addons I disabled by default