### PR TITLE
LBL: Updated lights to use new modes.

### DIFF
--- a/light_bridge_lights/scripts/vscripts/sv_init.nut
+++ b/light_bridge_lights/scripts/vscripts/sv_init.nut
@@ -11,13 +11,13 @@ function LBL_scriptInit() {
     }
 }
 
-LBL_LIGHT_COLOUR <- Vector(63, 196, 252)  // RGB colour values - light blue
-const LBL_LIGHT_BRIGHTNESS = 40
+LBL_LIGHT_COLOUR <- Vector(25, 175, 255)  // RGB colour values - light blue
+const LBL_LIGHT_BRIGHTNESS = 50
 const LBL_LIGHT_D50 = 50
 const LBL_LIGHT_D0 = 300
 const LBL_LIGHT_SHADOWSIZE = -1 // DONT CHANGE THIS FROM -1, it just instantly overwhelms the shadow atlas (-1 = no shadows)
 
-const LBL_LIGHT_SPACING = 20  // distance between lights in units, less spacing means more lights but a higher performance cost
+const LBL_LIGHT_SPACING = 24  // distance between lights in units, less spacing means more lights but a higher performance cost
 const LBL_LIGHT_MAXCOUNT = 128  // maximum number of lights per bridge to prevent performance issues
 
 const LBL_LIGHT_SPECIFIC_HEALTH = 27852 // used to identify lights created by this script
@@ -172,7 +172,9 @@ function LBL_lightCreate(pos) {    // returns light handle
     local light = null
 
     light = CreateEntityByName("light_rt", {
-        _lightmode = 3,
+        _specularmode = 0,
+        _indirectmode = 0,
+        _directmode = 2,
         spawnflags = 2
     })
     light.SetLightColor(LBL_LIGHT_COLOUR, LBL_LIGHT_BRIGHTNESS)
@@ -212,4 +214,4 @@ function LBL_lightRemoveAll() {
 }
 
 LBL_auto <- CreateEntityByName("logic_auto", {spawnflags = 1})
-LBL_auto.ConnectOutput("OnNewGame", "LBL_scriptInit")
+LBL_auto.ConnectOutput("OnMapSpawn", "LBL_scriptInit")


### PR DESCRIPTION
This PR updates the lights spawned by the Light Bridge Lights to use the new modes.
I opted to disable specular on the lights to prevent it being obvious where the lights actually are.

I also took this opportunity to slightly adjust the colour of the lights to better match the light bridge, and I fixed a bug where the bridge lights wouldn't be enabled after transitioning.

<img width="3839" height="2159" alt="Screenshot 2026-01-04 183605" src="https://github.com/user-attachments/assets/1842a1d0-fa8c-4386-af59-72107546b417" />
