### PR TITLE
Light Bridge Lights: Enable Volumetrics

### DIFF
--- a/light_bridge_lights/addon.kv3
+++ b/light_bridge_lights/addon.kv3
@@ -1,7 +1,7 @@
 <!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
 {
 	mod = "Dynamic Light Bridge Lights (★)"
-	description = "Adds dynamic lighting to light bridges, similar in style to our Clustered Renderer showcase video.\n\nWARNING: This addon can be very performance-heavy on lower-end hardware due to the number of lights it creates.\n\nThis addon is a stand-in solution until Area Lights have been implemented.\n\nVersion 1.0.2"
+	description = "Adds dynamic lighting to light bridges, similar in style to our Clustered Renderer showcase video.\n\nWARNING: This addon can be very performance-heavy on lower-end hardware due to the number of lights it creates.\n\nThis addon is a stand-in solution until Area Lights have been implemented.\n\nVersion 1.1.0"
 	type = ""
 	id = 0
 	thumbnail = ".assets/thumb.jpg"

--- a/light_bridge_lights/scripts/vscripts/sv_init.nut
+++ b/light_bridge_lights/scripts/vscripts/sv_init.nut
@@ -16,6 +16,8 @@ const LBL_LIGHT_BRIGHTNESS = 50
 const LBL_LIGHT_D50 = 50
 const LBL_LIGHT_D0 = 300
 const LBL_LIGHT_SHADOWSIZE = -1 // DONT CHANGE THIS FROM -1, it just instantly overwhelms the shadow atlas (-1 = no shadows)
+const LBL_LIGHT_VOLUMETRIC_LIGHTSCALE = 110
+const LBL_LIGHT_VOLUMETRIC_DENSITY = 0.025
 
 const LBL_LIGHT_SPACING = 24  // distance between lights in units, less spacing means more lights but a higher performance cost
 const LBL_LIGHT_MAXCOUNT = 128  // maximum number of lights per bridge to prevent performance issues
@@ -185,6 +187,11 @@ function LBL_lightCreate(pos) {    // returns light handle
     light.SetOrigin(pos)
 
     light.__KeyValueFromInt("max_health", LBL_LIGHT_SPECIFIC_HEALTH) // needed to detect light entities later
+
+    // needs adding like this for whatever reason
+    LBL_Dev.EntFireByHandleCompressed(light, "AddOutput", "_volumetricmode 2")
+    LBL_Dev.EntFireByHandleCompressed(light, "SetVolumetricLightScale", LBL_LIGHT_VOLUMETRIC_LIGHTSCALE.tostring())
+    LBL_Dev.EntFireByHandleCompressed(light, "SetVolumetricDensity", LBL_LIGHT_VOLUMETRIC_DENSITY.tostring())
 
     return light
 }


### PR DESCRIPTION
Updates the LBL addon to make the lights use volumetrics, as seen in the volumetric lighting blogpost (though slightly toned down).