### PR TITLE
Add ability for mappers to force enable/disable LBL addon.

### DIFF
--- a/light_bridge_lights/addon.kv3
+++ b/light_bridge_lights/addon.kv3
@@ -1,7 +1,7 @@
 <!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
 {
 	mod = "Dynamic Light Bridge Lights (★)"
-	description = "Adds dynamic lighting to light bridges, similar in style to our Clustered Renderer showcase video.\n\nWARNING: This addon can be very performance-heavy on lower-end hardware due to the number of lights it creates.\n\nThis addon is a stand-in solution until Area Lights have been implemented.\n\nVersion 1.1.0"
+	description = "Adds dynamic lighting to light bridges, similar in style to our Clustered Renderer showcase video.\n\nWARNING: This addon can be very performance-heavy on lower-end hardware due to the number of lights it creates.\n\nThis addon is a stand-in solution until Area Lights have been implemented.\n\nVersion 1.1.1"
 	type = "Other"
 	id = 0
 	thumbnail = ".assets/thumb.jpg"

--- a/light_bridge_lights/scripts/vscripts/sv_init.nut
+++ b/light_bridge_lights/scripts/vscripts/sv_init.nut
@@ -29,6 +29,8 @@ LBL_bridgeLightCountPrevious <- {}
 LBL_bridgesCacheMarkedForReset <- false
 const LBL_CACHE_REFRESH_TIME = 0.01
 
+LBL_lightsCanSpawn <- true
+
 // traces used for calculating bridge length
 const LBL_TRACE_DISTANCE = 8192
 LBL_TRACE_MASK <- MASK_SOLID | MASK_WATER | MASK_BLOCKLOS
@@ -49,6 +51,20 @@ function LBL_Setup() {
     loopTimer.ConnectOutput("OnTimer", "LBL_bridgeCacheRefresh")
     LBL_bridgeCacheRefresh()  // initial cache
 
+    // create relays for enabling/disabling lights for use by maps who want to force turn off lights
+    LBL_Dev.msgDeveloper("Creating force disable relay...")
+    local disableRelay = CreateEntityByName("logic_relay", {
+        targetname = "lightbridgelights_forcedisable"
+    })
+    disableRelay.ConnectOutput("OnTrigger", "LBL_Disable")
+
+    LBL_Dev.msgDeveloper("Creating force enable relay...")
+    local enableRelay = CreateEntityByName("logic_relay", {
+        targetname = "lightbridgelights_forceenable"
+    })
+    enableRelay.ConnectOutput("OnTrigger", "LBL_Enable")
+
+
     local loadAuto = CreateEntityByName("logic_auto", {}) // handle loading of saves
     loadAuto.ConnectOutput("OnLoadGame", "LBL_OnLoadGame")
 
@@ -66,6 +82,8 @@ function LBL_OnLoadGame() {
 }
 
 function LBL_bridgeCacheRefresh() {
+    if(!LBL_lightsCanSpawn) return
+
     if(LBL_bridgesCacheMarkedForReset) {
         LBL_bridgeCacheReset()
         LBL_bridgesCacheMarkedForReset = false
@@ -218,6 +236,20 @@ function LBL_lightRemoveAll() {
     }
 
     LBL_bridgeCacheReset()
+}
+
+function LBL_Enable() {
+    LBL_Dev.msgDeveloper("Enabling spawning lights...")
+
+    LBL_lightsCanSpawn = true
+    LBL_bridgeCacheRefresh()   // immediately refresh cache to spawn lights on all existing bridges
+}
+
+function LBL_Disable() {
+    LBL_Dev.msgDeveloper("Disabling spawning lights...")
+
+    LBL_lightsCanSpawn = false
+    LBL_lightRemoveAll()   // immediately remove all lights
 }
 
 LBL_auto <- CreateEntityByName("logic_auto", {spawnflags = 1})


### PR DESCRIPTION
This PR makes the script spawn two relays (`lightbridgelights_forcedisable` and `lightbridgelights_forceenable`), which can be used by mappers to force disable light bridge lights in their maps, no matter if the user has it mounted.

Requested to me in DMs by evely_one.